### PR TITLE
🔧 chore: configure Vite build output and Dockerfile updates

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -23,7 +23,7 @@ FROM nginx:alpine
 RUN rm -rf /usr/share/nginx/html/*
 
 # Copy built files from builder phase
-COPY --from=builder /app/build /usr/share/nginx/html
+COPY --from=builder /app/dist /usr/share/nginx/html
 
 # Copy custom Nginx configuration
 COPY nginx.conf /etc/nginx/nginx.conf

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -5,6 +5,9 @@ import path from 'path';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    outDir: 'dist', // Ensure this matches
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src')


### PR DESCRIPTION
- Confirmed Vite build output set to 'dist' in vite.config.js.
- Updated Dockerfile to copy build output from 'dist' directory.
- Ensured seamless integration of build process and deployment with Nginx.