### PR TITLE
Fix Alembic multiple head revisions error

### DIFF
--- a/backend/alembic/versions/merge_heads_2025_11_18.py
+++ b/backend/alembic/versions/merge_heads_2025_11_18.py
@@ -1,0 +1,33 @@
+"""Merge multiple heads
+
+Revision ID: merge_heads_2025_11_18
+Revises: 3acb4ca8f29c, 2ce3af1b254c
+Create Date: 2025-11-18 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'merge_heads_2025_11_18'
+down_revision: Union[str, None, tuple] = ('3acb4ca8f29c', '2ce3af1b254c')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """
+    Merge migration - no schema changes needed.
+    This migration simply merges two divergent heads into a single head.
+    """
+    pass
+
+
+def downgrade() -> None:
+    """
+    Downgrade will split back into two heads.
+    """
+    pass


### PR DESCRIPTION
This commit fixes the "Multiple head revisions are present" error that was occurring during deployment when running `alembic upgrade head`.

The issue was caused by two migration chains diverging from revision 8e9b8bb258c5, creating two separate heads:
- 3acb4ca8f29c (update_budgets_model_migrations_and_)
- 2ce3af1b254c (phase_3_nigerian_tax_implementation)

Created a merge migration that combines both heads into a single head, allowing migrations to run successfully during deployment.